### PR TITLE
create github action to untag labels on issues

### DIFF
--- a/.github/workflows/untag-issue-on-merge.yml
+++ b/.github/workflows/untag-issue-on-merge.yml
@@ -1,0 +1,36 @@
+name: Remove Label on Merge
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  remove-label:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Remove label from linked issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Extrae la descripción del PR
+          pr_body="${{ github.event.pull_request.body }}"
+          # Busca números de issues referenciados con la sintaxis #123
+          issues=$(echo "$pr_body" | grep -oE "#[0-9]+" | tr -d "#")
+          
+          for issue in $issues; do
+            # Verifica si el issue tiene la etiqueta y luego la elimina
+            curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/${{ github.repository }}/issues/$issue/labels \
+              | grep -q '"pending release"' && \
+            curl -X DELETE \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              https://api.github.com/repos/${{ github.repository }}/issues/$issue/labels/nombre-de-la-etiqueta
+          done


### PR DESCRIPTION
Se añade una acción para eliminar automáticamente los labels "pending deployment" cuando la rama ha sido efectivamente desplegada a main y se cierre el issue.